### PR TITLE
feat(core): support to return current routing information API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 cypress/videos
 cypress/screenshots
 coverage
+.DS_Store

--- a/packages/core/__test__/plugin.test.js
+++ b/packages/core/__test__/plugin.test.js
@@ -148,3 +148,43 @@ test('The configuration file should be loaded correctly', () => {
     ssr: true
   })
 })
+
+test('getRouteMeta should be succeed', () => {
+  const pluginApi = new PluginApi()
+  const meta = { foo: 'bar' }
+  pluginApi.router = { resolve (path) { return { resolved: { matched: [{ path: '/fake/path' }], meta } } } }
+  expect(pluginApi.getRouteMeta('/fake/path')).toEqual(meta)
+})
+
+test('getRouteMeta should be failed without route', () => {
+  const pluginApi = new PluginApi()
+  expect(pluginApi.getRouteMeta('/fake/path')).toBeNull()
+})
+
+test('getRouteMeta should be failed no matched', () => {
+  const pluginApi = new PluginApi()
+  const meta = null
+  pluginApi.router = { resolve (path) { return { resolved: { matched: [], meta } } } }
+  expect(pluginApi.getRouteMeta('/fake/path')).toBeNull()
+})
+
+test('getRouteInfo should be succeed', () => {
+  const pluginApi = new PluginApi()
+  const meta = {}
+  const resolved = { matched: [{ path: '/fake/path' }], meta }
+  pluginApi.router = { resolve (path) { return { resolved } } }
+  expect(pluginApi.getRouteInfo('/fake/path')).toEqual(resolved)
+})
+
+test('getRouteInfo should be failed without route', () => {
+  const pluginApi = new PluginApi()
+  expect(pluginApi.getRouteInfo('/fake/path')).toEqual({})
+})
+
+test('getRouteInfo should be failed no matched', () => {
+  const pluginApi = new PluginApi()
+  const meta = {}
+  const resolved = { matched: [], meta }
+  pluginApi.router = { resolve (path) { return { resolved } } }
+  expect(pluginApi.getRouteInfo('/fake/path')).toEqual({})
+})

--- a/packages/core/lib/PluginApi.js
+++ b/packages/core/lib/PluginApi.js
@@ -90,11 +90,17 @@ class PluginApi {
     this.middlewares[type].add(fn)
   }
 
-  getRouteMeta (location) {
-    if (!this.router) return null
+  getRouteInfo (location) {
+    if (!this.router) return {}
     const res = this.router.resolve({ path: location })
-    if (!res.resolved.matched.length) return null
-    return res.resolved.meta
+    if (!res.resolved.matched.length) return {}
+    return res.resolved
+  }
+
+  getRouteMeta (location) {
+    const routeInfo = this.getRouteInfo(location)
+
+    return routeInfo.meta || null
   }
 
   hookInto (name, fn) {


### PR DESCRIPTION
affects: @vapper/core

ISSUES CLOSED: #7